### PR TITLE
Allow shared libraries to be loaded from repo workspace PREVIEW

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryDecorator.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryDecorator.java
@@ -126,6 +126,9 @@ import org.jenkinsci.plugins.workflow.cps.GroovyShellDecorator;
                             addition.addTo(execution);
                         }
                     }
+
+                    new WorkspaceLibraryAdder().add(execution, libraries, changelogs);
+
                     if (!libraries.isEmpty()) {
                         throw new AbortException(Messages.LibraryDecorator_could_not_find_any_definition_of_librari(libraries));
                     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/WorkspaceLibraryAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/WorkspaceLibraryAdder.java
@@ -1,0 +1,43 @@
+package org.jenkinsci.plugins.workflow.libs;
+
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+
+public class WorkspaceLibraryAdder extends ClasspathAdder {
+
+    @Nonnull
+    @Override
+    public List<Addition> add(@Nonnull CpsFlowExecution execution, @Nonnull List<String> libraries, @Nonnull HashMap<String, Boolean> changelogs) throws Exception {
+        List<Addition> additions = new ArrayList<>();
+
+        Iterator<String> iterator = libraries.iterator();
+        while (iterator.hasNext()) {
+            String path = getWorkspaceLibraryPath(execution, iterator.next());
+            File libraryPath = new File(path);
+            if (libraryPath.exists()) {
+                iterator.remove();
+                Addition addition = new Addition(libraryPath.toURI().toURL(), false);
+                addition.addTo(execution);
+                additions.add(addition);
+            }
+        }
+
+        return additions;
+    }
+
+    private String getWorkspaceLibraryPath(CpsFlowExecution execution, String library) throws IOException {
+        String url = execution.getUrl(); // e.g. "job/Directory/job/JobName/34/execution/"
+        String[] parts = url.substring(4).split("/job/");
+        parts[parts.length - 1] = parts[parts.length - 1].split("/")[0];
+        String partialPath = StringUtils.join(parts, "/");
+        return String.format("%s/workspace/%s@script/%s", System.getenv("JENKINS_HOME"), partialPath, library);
+    }
+}


### PR DESCRIPTION
The purpose of this PR is to solve [JENKINS-46721](https://issues.jenkins-ci.org/browse/JENKINS-46721) - Expect library sources in custom subdirectory

This PR is a combination of ideas based on the work done in https://github.com/karolgil/SharedLibrary , https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/40 and https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/37

The WorkspaceLibraryAdder checks to see if any paths specified in ```@Library()``` exist in the workspace. If they exist those paths are added to the classpath of the non-trusted shell.